### PR TITLE
Added ID for jDrone UC4H Gen.Node v2.1 board

### DIFF
--- a/jdrone-uc4h-v2.cmake
+++ b/jdrone-uc4h-v2.cmake
@@ -1,0 +1,3 @@
+set(uavcanblid_hw_version_major 2)
+set(uavcanblid_hw_version_minor 1)
+set(uavcanblid_name "\"fixme.org.jdrone.uc4h-v2\"")


### PR DESCRIPTION
Named `fixme.org.jdrone.uc4h-v2` as temporary ID as I don't own the _**org.jdrone**_ prefix and have no right to make use of it.